### PR TITLE
fix: Disable SSR in default build to resolve routing errors

### DIFF
--- a/spicy-fairytales/angular.json
+++ b/spicy-fairytales/angular.json
@@ -32,11 +32,7 @@
             "styles": [
               "src/styles.scss"
             ],
-            "server": "src/main.server.ts",
-            "outputMode": "server",
-            "ssr": {
-              "entry": "src/server.ts"
-            }
+            "outputMode": "static"
           },
           "configurations": {
             "production": {

--- a/spicy-fairytales/package.json
+++ b/spicy-fairytales/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "node dist/spicy-fairytales/server/server.mjs",
+    "start": "ng serve",
     "start:dev": "ng serve",
     "build": "ng build",
     "build:github-pages": "ng build --configuration github-pages",
@@ -12,8 +12,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "validate": "node validate-env.js",
-    "test-apis": "node test-apis.js",
-    "serve:ssr:spicy-fairytales": "node dist/spicy-fairytales/server/server.mjs"
+    "test-apis": "node test-apis.js"
   },
   "prettier": {
     "printWidth": 100,

--- a/spicy-fairytales/src/app/app.routes.server.ts
+++ b/spicy-fairytales/src/app/app.routes.server.ts
@@ -16,7 +16,7 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
   {
-    path: '**',
+    path: '',
     renderMode: RenderMode.Prerender
   }
 ];


### PR DESCRIPTION
The app was failing to build due to SSR route extraction errors. The issue was that the default production build had SSR enabled, but the deployment configurations (github-pages, vercel, staging) all used static builds.

Changes:
- Disabled SSR in default build configuration (angular.json)
- Updated server routes to use empty path instead of wildcard
- Updated start script to use ng serve instead of SSR server
- Removed obsolete SSR-specific npm scripts

The app now builds successfully as a static SPA, consistent with the deployment configurations that were already working.

## Description
Brief description of the changes made in this PR.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update
- [ ] 🔒 Security update
- [ ] 🔄 CI/CD update

## Changes Made
### Frontend
- 

### Backend/Services
- 

### Infrastructure
- 

### Documentation
- 

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [ ] Manual testing completed
- [ ] Accessibility tested

## Screenshots (if applicable)
<!-- Add screenshots of UI changes -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Any additional information or context about this PR -->

## Summary by Sourcery

Disable server-side rendering in the default Angular build so the app builds and runs as a static SPA.

Bug Fixes:
- Resolve SSR route extraction build failures by switching the default build output to static rendering.

Build:
- Update Angular build configuration to use static output mode instead of SSR for the default project.
- Adjust server-side prerender route to use an empty path for static builds.

Chores:
- Simplify npm scripts by changing the default start command to `ng serve` and removing obsolete SSR server scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Transitioned application from Server-Side Rendering to static site generation for improved performance and deployment flexibility.
  * Updated development server startup process with simplified build configuration.
  * Adjusted route prerendering strategy to focus on core application paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->